### PR TITLE
implementação dos reports, CLI, GUI e alguns asserts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,27 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+        </dependency>    
+         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+             
     </dependencies>
     <!--
        It was necessary to include the following lines to fix the

--- a/src/main/java/br/unb/cic/test/unit/DefaultReport.java
+++ b/src/main/java/br/unb/cic/test/unit/DefaultReport.java
@@ -1,0 +1,16 @@
+package br.unb.cic.test.unit;
+
+public class DefaultReport extends Report {
+
+    @Override
+    public void export() {
+        for (TestResult result : testResults) {
+            System.out.println("Test Case: " + result.getTestCaseName());
+            System.out.println("Successes: " + result.getSuccesses());
+            System.out.println("Errors: " + result.getErrors());
+            System.out.println("Failures: " + result.getFailures());
+            System.out.println();
+        }
+    }
+}
+

--- a/src/main/java/br/unb/cic/test/unit/DefaultRunner.java
+++ b/src/main/java/br/unb/cic/test/unit/DefaultRunner.java
@@ -11,10 +11,16 @@ import java.util.Set;
  * from <code>TestCase</code>.
  */
 public class DefaultRunner extends TestRunner {
+
+    @Inject
+    public DefaultRunner(Set<Report> reports) {
+        super(reports);
+    }
+    
     @Override
-    public Set<TestCase> listTestCases() {
+    public Set<TestCase> listTestCases(String packagePath) {
         try {
-            Reflections reflections = new Reflections();
+            Reflections reflections = new Reflections(packagePath);
             Set<Class<? extends TestCase>> testCaseClasses = reflections.getSubTypesOf(TestCase.class);
             Set<TestCase> testCases = new HashSet<>();
             for (Class<? extends TestCase> c : testCaseClasses) {

--- a/src/main/java/br/unb/cic/test/unit/DefaultRunner.java
+++ b/src/main/java/br/unb/cic/test/unit/DefaultRunner.java
@@ -1,8 +1,12 @@
 package br.unb.cic.test.unit;
 
 import br.unb.cic.test.unit.eh.Failure;
+import com.google.inject.Inject;
 import org.reflections.Reflections;
 
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,9 +24,14 @@ public class DefaultRunner extends TestRunner {
     @Override
     public Set<TestCase> listTestCases(String packagePath) {
         try {
+
+
             Reflections reflections = new Reflections(packagePath);
             Set<Class<? extends TestCase>> testCaseClasses = reflections.getSubTypesOf(TestCase.class);
             Set<TestCase> testCases = new HashSet<>();
+
+
+
             for (Class<? extends TestCase> c : testCaseClasses) {
                 testCases.add(c.newInstance());
             }

--- a/src/main/java/br/unb/cic/test/unit/JsonReportGenerator.java
+++ b/src/main/java/br/unb/cic/test/unit/JsonReportGenerator.java
@@ -1,0 +1,47 @@
+package br.unb.cic.test.unit;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Set;
+
+public class JsonReportGenerator extends Report {
+
+
+    @Override
+    public void export() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonObject reportObject = new JsonObject();
+
+        JsonArray testResultsArray = new JsonArray();
+        for (TestResult testResult : testResults) {
+            JsonObject testResultObject = new JsonObject();
+            testResultObject.addProperty("testCase", testResult.getTestCaseName());
+            testResultObject.add("successes", toJsonArray(testResult.getSuccesses()));
+            testResultObject.add("errors", toJsonArray(testResult.getErrors()));
+            testResultObject.add("failures", toJsonArray(testResult.getFailures()));
+            testResultsArray.add(testResultObject);
+        }
+
+        reportObject.add("testResults", testResultsArray);
+
+        try (FileWriter writer = new FileWriter(filePath + ".json")) {
+            gson.toJson(reportObject, writer);
+        } catch (IOException e) {
+            System.err.println("Error exporting JSON report: " + e.getMessage());
+        }
+    }
+
+    private JsonArray toJsonArray(Set<String> strings) {
+        JsonArray jsonArray = new JsonArray();
+        for (String string : strings) {
+            jsonArray.add(string);
+        }
+        return jsonArray;
+    }
+
+}

--- a/src/main/java/br/unb/cic/test/unit/Report.java
+++ b/src/main/java/br/unb/cic/test/unit/Report.java
@@ -1,0 +1,15 @@
+package br.unb.cic.test.unit;
+
+import java.util.Set;
+
+public abstract class Report {
+        public String filePath;
+        Set<TestResult> testResults;
+        public abstract void export();
+
+        public void setFilePath(String filePath) {
+                this.filePath = filePath;
+        }
+        public void setResult(Set<TestResult> testResults) {this.testResults = testResults;}
+
+}

--- a/src/main/java/br/unb/cic/test/unit/ReportManager.java
+++ b/src/main/java/br/unb/cic/test/unit/ReportManager.java
@@ -1,0 +1,44 @@
+package br.unb.cic.test.unit;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class ReportManager {
+
+    private final Map<String, Class<? extends Report>> reportTypeMap;
+
+    public ReportManager() {
+        reportTypeMap = new HashMap<>();
+        reportTypeMap.put("default", DefaultReport.class);
+        reportTypeMap.put("json", JsonReportGenerator.class);
+        // Add more report types here
+    }
+
+    public Map<String, Class<? extends Report>> getReportTypemap() {
+
+        return reportTypeMap;
+    }
+
+    public void exportReport(Set<Report> reports, String reportType, String filePath, Set<TestResult> results) {
+        Class<? extends Report> reportClass = reportTypeMap.get(reportType);
+
+        if (reportClass == null) {
+            throw new IllegalArgumentException("Unsupported report type: " + reportType);
+        }
+
+
+
+        for (Report report : reports) {
+            if (reportClass.isInstance(report)) {
+                report.setFilePath(filePath);
+                report.setResult(results);
+                report.export();
+                return;
+            }
+        }
+
+        throw new IllegalArgumentException("Report of type " + reportType + " not found in the reports list.");
+    }
+
+}

--- a/src/main/java/br/unb/cic/test/unit/ReportModule.java
+++ b/src/main/java/br/unb/cic/test/unit/ReportModule.java
@@ -1,0 +1,18 @@
+package br.unb.cic.test.unit;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class ReportModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        Multibinder<Report> reportMultibinder = Multibinder.newSetBinder(binder(), Report.class);
+
+
+
+        reportMultibinder.addBinding().to(DefaultReport.class);
+        reportMultibinder.addBinding().to(JsonReportGenerator.class);
+        // new reports here
+    }
+}

--- a/src/main/java/br/unb/cic/test/unit/SuiteRunner.java
+++ b/src/main/java/br/unb/cic/test/unit/SuiteRunner.java
@@ -1,6 +1,7 @@
 package br.unb.cic.test.unit;
 
 import br.unb.cic.test.unit.eh.TestCaseInstantiationError;
+import com.google.inject.Inject;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/br/unb/cic/test/unit/SuiteRunner.java
+++ b/src/main/java/br/unb/cic/test/unit/SuiteRunner.java
@@ -13,7 +13,9 @@ import java.util.Set;
 public class SuiteRunner extends TestRunner {
     private Set<Class<? extends TestCase>> testClasses;
 
-    public SuiteRunner() {
+    @Inject
+    public SuiteRunner(Set<Report> reports) {
+        super(reports);
         testClasses = new HashSet<>();
     }
 
@@ -29,7 +31,7 @@ public class SuiteRunner extends TestRunner {
     }
 
     @Override
-    public Set<TestCase> listTestCases() {
+    public Set<TestCase> listTestCases(String packagePath) {
         Set<TestCase> testCases = new HashSet<>();
         for (Class<? extends TestCase> c : testClasses) {
             try {

--- a/src/main/java/br/unb/cic/test/unit/TestCase.java
+++ b/src/main/java/br/unb/cic/test/unit/TestCase.java
@@ -38,6 +38,30 @@ public abstract class TestCase {
         }
     }
 
+    protected void assertNotNull(Object object) {
+        if (object == null) {
+            throw new AssertException();
+        }
+    }
+
+    protected void assertNotEquals(Object o1, Object o2) {
+        if (o1.equals(o2)) {
+            throw new AssertException();
+        }
+    }
+
+    protected void assertArrayEquals(Object[] arr1, Object[] arr2) {
+        if (!Arrays.equals(arr1, arr2)) {
+            throw new AssertException();
+        }
+    }
+
+    protected void assertGreaterThan(int value1, int value2) {
+        if (value1 <= value2) {
+            throw new AssertException();
+        }
+    }
+
     public void before() {}
     public void after() {};
 

--- a/src/main/java/br/unb/cic/test/unit/TestCase.java
+++ b/src/main/java/br/unb/cic/test/unit/TestCase.java
@@ -5,6 +5,7 @@ import br.unb.cic.test.unit.eh.AssertException;
 import br.unb.cic.test.unit.eh.AssertTrueException;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 /**
  * Define the root of the Test Case class hierarchy.

--- a/src/main/java/br/unb/cic/test/unit/TestFrameworkCLI.java
+++ b/src/main/java/br/unb/cic/test/unit/TestFrameworkCLI.java
@@ -1,0 +1,143 @@
+package br.unb.cic.test.unit;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.commons.cli.*;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+// Exemplo de commando --type default --out json --file report
+
+public class TestFrameworkCLI {
+    private static final String TYPE_OPTION = "type";
+    private static final String SILENT_OPTION = "silent";
+    private static final String PACKAGE_OPTION = "package";
+    private static final String OUT_OPTION = "out";
+    private static final String FILE_OPTION = "file";
+
+    private static final ReportManager reportManager = new ReportManager();
+
+
+
+    public static void main(String[] args) {
+        CommandLineParser parser = new DefaultParser();
+        Options options = createOptions();
+
+        try {
+            CommandLine cmd = parser.parse(options, args);
+
+            Injector injector = Guice.createInjector(new ReportModule());
+
+            if (cmd.hasOption(TYPE_OPTION)) {
+
+                String type = cmd.getOptionValue(TYPE_OPTION);
+
+                Set<Report> reports = new HashSet<>();
+
+
+
+                if (type.equalsIgnoreCase("default")) {
+
+                    DefaultRunner runner = injector.getInstance(DefaultRunner.class);
+                    runTests(cmd, runner);
+                } else if (type.equalsIgnoreCase("suite")) {
+                    SuiteRunner runner = injector.getInstance(SuiteRunner.class);
+                    runTests(cmd, runner);
+                } else {
+                    System.err.println("Invalid test type: " + type);
+                }
+            } else {
+                System.err.println("Test type not specified.");
+                printHelp(options);
+            }
+        } catch (ParseException e) {
+            System.err.println("Error parsing command-line arguments: " + e.getMessage());
+            printHelp(options);
+        }
+    }
+
+    private static Options createOptions() {
+        Options options = new Options();
+
+        options.addOption(Option.builder(TYPE_OPTION)
+                .longOpt("type")
+                .argName("testType")
+                .desc("Specify the type of test (default or suite)")
+                .hasArg()
+                .required()
+                .build());
+
+        options.addOption(Option.builder(SILENT_OPTION)
+                .longOpt("silent")
+                .desc("Run the tests silently without printing the default report")
+                .build());
+
+        options.addOption(Option.builder(PACKAGE_OPTION)
+                .longOpt("package")
+                .argName("package path")
+                .desc("Specify the package where the testCases are located")
+                .hasArg()
+                .build());
+
+        options.addOption(Option.builder(OUT_OPTION)
+                .longOpt("out")
+                .argName("fileType")
+                .desc("Specify the type of output file for the report")
+                .hasArg()
+                .build());
+
+        options.addOption(Option.builder(FILE_OPTION)
+                .longOpt("file")
+                .argName("path")
+                .desc("Specify the file path for the report, include the name of the file")
+                .hasArg()
+                .required()
+                .build());
+
+        return options;
+    }
+
+    private static void runTests(CommandLine cmd, TestRunner runner) {
+        boolean silent = cmd.hasOption(SILENT_OPTION);
+        String packagePath = cmd.getOptionValue(PACKAGE_OPTION, "br.unb.cic.test.unit.samples");
+        String fileType = cmd.getOptionValue(OUT_OPTION, "");
+        String filePath = cmd.getOptionValue(FILE_OPTION);
+
+
+        Set<TestResult> results = runner.runAllTests(packagePath);
+
+
+        Map<String, Class<? extends Report>> reportTypeMap = reportManager.getReportTypemap();
+
+
+        if (!silent) {
+
+            reportManager.exportReport(runner.getReports(), "default", filePath, results);
+        }
+
+        if (fileType.isEmpty()) {
+
+            for (String reportType : reportTypeMap.keySet()) {
+                if (reportType.equals("default")) {
+                    continue; // Skip exporting DefaultReport when silent mode is enabled
+                }
+
+                reportManager.exportReport(runner.getReports(), reportType, filePath, results);
+            }
+        } else {
+
+            reportManager.exportReport(runner.getReports(), fileType, filePath, results);
+
+        }
+
+    }
+
+
+    private static void printHelp(Options options) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("test-framework-cli", options, true);
+    }
+}
+

--- a/src/main/java/br/unb/cic/test/unit/TestResultGUI.java
+++ b/src/main/java/br/unb/cic/test/unit/TestResultGUI.java
@@ -1,0 +1,64 @@
+package br.unb.cic.test.unit;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class TestResultGUI extends JFrame{
+    private TestResult testResult;
+
+    public TestResultGUI(TestResult testResult) {
+        this.testResult = testResult;
+        initialize();
+    }
+
+    private void initialize() {
+        setTitle("Test Result");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setSize(400, 300);
+        setLocationRelativeTo(null);
+
+        // Create the main panel
+        JPanel mainPanel = new JPanel();
+        mainPanel.setLayout(new BorderLayout());
+
+        // Create the title label
+        JLabel titleLabel = new JLabel("Test Case: " + testResult.getTestCaseName());
+        titleLabel.setFont(new Font("Arial", Font.BOLD, 18));
+        titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        mainPanel.add(titleLabel, BorderLayout.NORTH);
+
+        // Create the results panel
+        JPanel resultsPanel = new JPanel(new GridLayout(3, 1));
+
+        // Create the success label
+        JLabel successLabel = new JLabel("Successes: " + testResult.getSuccesses().size());
+        resultsPanel.add(successLabel);
+
+        // Create the error label
+        JLabel errorLabel = new JLabel("Errors: " + testResult.getErrors().size());
+        resultsPanel.add(errorLabel);
+
+        // Create the failure label
+        JLabel failureLabel = new JLabel("Failures: " + testResult.getFailures().size());
+        resultsPanel.add(failureLabel);
+
+        mainPanel.add(resultsPanel, BorderLayout.CENTER);
+
+        // Add the main panel to the frame
+        add(mainPanel);
+    }
+
+    public static void main(String[] args) {
+        // Example usage
+        TestResult testResult = new TestResult("ExampleTestCase");
+        testResult.reportSuccess("testMethod1");
+        testResult.reportSuccess("testMethod2");
+        testResult.reportError("testMethod3");
+        testResult.reportFailure("testMethod4");
+
+        SwingUtilities.invokeLater(() -> {
+            TestResultGUI gui = new TestResultGUI(testResult);
+            gui.setVisible(true);
+        });
+    }
+}

--- a/src/main/java/br/unb/cic/test/unit/TestRunner.java
+++ b/src/main/java/br/unb/cic/test/unit/TestRunner.java
@@ -8,8 +8,17 @@ import java.util.Set;
  * override the abstract method <code>listTestCases()</code>.
  */
 public abstract class TestRunner {
-    public abstract Set<TestCase> listTestCases();
+    public abstract Set<TestCase> listTestCases(String packagePath);
 
+    public Set<Report> reports;
+
+
+    @Inject
+    public TestRunner(Set<Report> reports) {
+        this.reports = reports;
+    }
+
+    public Set<Report> getReports() {return reports;}
     /**
      * This is a (template) method that executes all
      * test cases coming from <code>listTestCases</code>.
@@ -17,8 +26,8 @@ public abstract class TestRunner {
      * @return Return a set of test results---one for each test case
      * in run.
      */
-    public Set<TestResult> runAllTests() {
-        Set<TestCase> testCases = listTestCases();
+    public Set<TestResult> runAllTests(String packagePath) {
+        Set<TestCase> testCases = listTestCases(packagePath);
         Set<TestResult> result = new HashSet<>();
         for(TestCase tc: testCases) {
             result.add(tc.run());

--- a/src/main/java/br/unb/cic/test/unit/TestRunner.java
+++ b/src/main/java/br/unb/cic/test/unit/TestRunner.java
@@ -1,5 +1,7 @@
 package br.unb.cic.test.unit;
 
+import com.google.inject.Inject;
+
 import java.util.HashSet;
 import java.util.Set;
 

--- a/src/test/java/br/unb/cic/test/unit/DefaultRunnerTest.java
+++ b/src/test/java/br/unb/cic/test/unit/DefaultRunnerTest.java
@@ -13,9 +13,10 @@ public class DefaultRunnerTest {
     @Test
     public void listTestCases() {
         DefaultRunner runner = new DefaultRunner();
-
-        Assert.assertTrue(!runner.listTestCases().isEmpty());
-        Assert.assertEquals(2, runner.listTestCases().size());
+        String packagePath = "br.unb.cic.test.unit.samples";
+        
+        Assert.assertTrue(!runner.listTestCases("br.unb.cic.test.unit.samples").isEmpty());
+        Assert.assertEquals(2, runner.listTestCases("br.unb.cic.test.unit.samples").size());
     }
 
 
@@ -23,7 +24,7 @@ public class DefaultRunnerTest {
     public void executeSampleTestes() {
         DefaultRunner runner = new DefaultRunner();
 
-        Set<TestResult> results = runner.runAllTests();
+        Set<TestResult> results = runner.runAllTests("br.unb.cic.test.unit.samples");
 
         int success = results.stream().map(result -> result.getSuccesses().size()).reduce(Integer::sum).get();
         int failures = results.stream().map(result -> result.getFailures().size()).reduce(Integer::sum).get();

--- a/src/test/java/br/unb/cic/test/unit/DefaultRunnerTest.java
+++ b/src/test/java/br/unb/cic/test/unit/DefaultRunnerTest.java
@@ -3,6 +3,7 @@ package br.unb.cic.test.unit;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -12,17 +13,19 @@ public class DefaultRunnerTest {
 
     @Test
     public void listTestCases() {
-        DefaultRunner runner = new DefaultRunner();
+        Set<Report> reports = new HashSet<>();
+        DefaultRunner runner = new DefaultRunner(reports);
         String packagePath = "br.unb.cic.test.unit.samples";
         
-        Assert.assertTrue(!runner.listTestCases("br.unb.cic.test.unit.samples").isEmpty());
-        Assert.assertEquals(2, runner.listTestCases("br.unb.cic.test.unit.samples").size());
+        Assert.assertTrue(!runner.listTestCases(packagePath).isEmpty());
+        Assert.assertEquals(2, runner.listTestCases(packagePath).size());
     }
 
 
     @Test
     public void executeSampleTestes() {
-        DefaultRunner runner = new DefaultRunner();
+        Set<Report> reports = new HashSet<>();
+        DefaultRunner runner = new DefaultRunner(reports);
 
         Set<TestResult> results = runner.runAllTests("br.unb.cic.test.unit.samples");
 

--- a/src/test/java/br/unb/cic/test/unit/TestFrameworkCLI.java
+++ b/src/test/java/br/unb/cic/test/unit/TestFrameworkCLI.java
@@ -1,10 +1,10 @@
 package br.unb.cic.test.unit;
 
+import br.unb.cic.test.unit.*;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.commons.cli.*;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +34,7 @@ public class TestFrameworkCLI {
 
                 String type = cmd.getOptionValue(TYPE_OPTION);
 
-                Set<Report> reports = new HashSet<>();
+
 
 
 


### PR DESCRIPTION
Nesse trabalho, criei uma classe abstrata chamada Report. Vários reports herdam dessa classe, criei um ReportManager e uma classe de TestFrameworkCLI.

Eu clonei o repositório ao invés de criar um fork, por isso que os commits estão dessa forma.

A classe Report é um atributo do testRunner.

esse atributo contém um set de tipos de report instanciados pelo guice. 

Criei um CLI que especifica tipo do test, configuração de exportação dos reports, caminho dos reports 
e o package em que os testes estão inseridos.

Notei que os testCases não estavam recebendo os testes. Para resolver, precisava adicionar
o caminho do package nos parametro do objeto reflection.

Minha maior dificuldade foi relacionar as classes, entender a interação entre elas e  
flexibilizar a implementação para facilitar outras implementações no futuro. 

Sobre a questão do CLI, ele funciona na pasta de teste, mas não na pasta main. Para que essa classe funcione na main os testes precisam estar na pasta main também. nesse caso, o Junit também funciona.

Gostaria de saber se essa parte é satisfatória para o senhor. 

Gabriel Brito de França - 211020867 - reports e cli
Nicole Sena - Asserts no testCase e GUI